### PR TITLE
Allow custom document to be provided

### DIFF
--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -18,6 +18,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
   (
     {
       children,
+      doc = document,
       isOpen,
       onClose,
       onOpenStart,
@@ -150,7 +151,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
             </AnimatePresence>
           </div>
         </SheetContext.Provider>,
-        document.body
+        doc.body
       )
     ) : (
       // NOTE: return the wrapper div so that SSR frameworks don't get confused

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -15,6 +15,7 @@ export type SheetEvents = {
 export type SheetProps = {
   isOpen: boolean;
   children: React.ReactNode;
+  doc?: Document;
   onClose: () => void;
   rootId?: string;
   snapPoints?: number[];


### PR DESCRIPTION
Hi @Temzasse. First of all, thank you for creating this library! It looks fantastic and has such an intuitive + flexible API.

This change would allow a custom document to be provided (useful in cases where you are rendering into an iframe).

Let me know what you think :)