### PR TITLE
Update README to add ref to snapTo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ function Example() {
 
       {/* Opens to 400 since initial index is 1 */}
       <Sheet
+        ref={ref}
         isOpen={isOpen}
         onClose={() => setOpen(false)}
         snapPoints={[600, 400, 100, 0]}


### PR DESCRIPTION
While adding `snapTo` functionality to our product that uses this package, I noticed that the example is missing the `ref` prop to the `Sheet` component that is needed for the method to work.

 