### PR TITLE
Fix snapTo null error

### DIFF
--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -115,11 +115,14 @@ const Sheet = React.forwardRef<any, SheetProps>(
     React.useImperativeHandle(ref, () => ({
       y,
       snapTo: (snapIndex: number) => {
-        if (snapPoints && snapPoints[snapIndex] !== undefined) {
-          const sheetEl = sheetRef.current as HTMLDivElement;
+        const sheetEl = sheetRef.current as HTMLDivElement | null;
+        if (
+          snapPoints &&
+          snapPoints[snapIndex] !== undefined &&
+          sheetEl !== null
+        ) {
           const contentHeight = sheetEl.getBoundingClientRect().height;
           const snapTo = contentHeight - snapPoints[snapIndex];
-
           animate(y, snapTo, { type: 'spring', ...springConfig });
           if (onSnap) onSnap(snapIndex);
           if (snapTo >= contentHeight) onClose();


### PR DESCRIPTION
If the drawer is closed, a call to snapTo will produce and error trying to access getBoundingRectBox
![image](https://user-images.githubusercontent.com/541285/154140343-ccc52f75-94a5-4dbf-a3ed-286281651eb1.png)

![image](https://user-images.githubusercontent.com/541285/154140498-35dbe378-5eeb-498f-ab55-836829f5cb75.png)
