### PR TITLE
Make the style prop of Sheet functional

### DIFF
--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -30,6 +30,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
       rootId,
       springConfig = { stiffness: 300, damping: 30, mass: 0.2 },
       disableDrag = false,
+      style,
       ...rest
     },
     ref
@@ -159,7 +160,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
     const wrapperProps = {
       ...rest,
       ref,
-      style: styles.wrapper,
+      style: { ...styles.wrapper, ...style },
     };
 
     const sheet = (


### PR DESCRIPTION
The prop `style` of Sheet is non-functional because it's overwritten by the package's included styles. This change allows users to override any part of the default style for the Sheet component. In my case, I need to change the z-index of the Sheet component.