### PR TITLE
Skip y animation if user prefers reduced motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,24 @@ Also, by constructing the sheet from smaller pieces makes it easier to apply any
 
 ## Props
 
-| Name           | Required | Default          | Description                                                                                                                                                                                                                       |
-| -------------- | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`     | yes      |                  | Use `Sheet.Container/Content/Header/Backdrop` to compose your bottom sheet.                                                                                                                                                       |
-| `isOpen`       | yes      |                  | Boolean that indicates whether the sheet is open or not.                                                                                                                                                                          |
-| `onClose`      | yes      |                  | Callback fn that is called when the sheet is closed by the user.                                                                                                                                                                  |
-| `disableDrag`  | no       | false            | Disable drag for the whole sheet.                                                                                                                                                                                                 |
-| `detent`       | no       | `'full-height'`  | The [detent](https://developer.apple.com/design/human-interface-guidelines/components/presentation/sheets#ios-ipados) in which the sheet should be in when opened. Available values: `'full-height'` or `'content-height'`.       |
-| `onOpenStart`  | no       |                  | Callback fn that is called when the sheet opening animation starts.                                                                                                                                                               |
-| `onOpenEnd`    | no       |                  | Callback fn that is called when the sheet opening animation is completed.                                                                                                                                                         |
-| `onCloseStart` | no       |                  | Callback fn that is called when the sheet closing animation starts.                                                                                                                                                               |
-| `onCloseEnd`   | no       |                  | Callback fn that is called when the sheet closing animation is completed.                                                                                                                                                         |
-| `onSnap`       | no       |                  | Callback fn that is called with the current snap point index when the sheet snaps to a new snap point. Requires `snapPoints` prop.                                                                                                |
-| `snapPoints`   | no       |                  | Eg. `[-50, 0.5, 100, 0]` - where positive values are pixels from the bottom of the screen and negative from the top. Values between 0-1 represent percentages, eg. `0.5` means 50% of window height from the bottom of the sceen. |
-| `initialSnap`  | no       | 0                | Initial snap point when sheet is opened (index from `snapPoints`).                                                                                                                                                                |
-| `rootId`       | no       |                  | The id of the element where the main app is mounted, eg. "root". Enables iOS modal effect.                                                                                                                                        |
-| `springConfig` | no       | `DEFAULT_SPRING` | Overrides the config for the [spring animation](https://www.framer.com/api/motion/types/#spring).                                                                                                                                 |
-| `mountPoint`   | no       | `document.body`  | HTML element that should be used as the mount point for the sheet.                                                                                                                                                                |
+| Name                   | Required | Default          | Description                                                                                                                                                                                                                       |
+|------------------------|----------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `children`             | yes      |                  | Use `Sheet.Container/Content/Header/Backdrop` to compose your bottom sheet.                                                                                                                                                       |
+| `isOpen`               | yes      |                  | Boolean that indicates whether the sheet is open or not.                                                                                                                                                                          |
+| `onClose`              | yes      |                  | Callback fn that is called when the sheet is closed by the user.                                                                                                                                                                  |
+| `disableDrag`          | no       | false            | Disable drag for the whole sheet.                                                                                                                                                                                                 |
+| `detent`               | no       | `'full-height'`  | The [detent](https://developer.apple.com/design/human-interface-guidelines/components/presentation/sheets#ios-ipados) in which the sheet should be in when opened. Available values: `'full-height'` or `'content-height'`.       |
+| `onOpenStart`          | no       |                  | Callback fn that is called when the sheet opening animation starts.                                                                                                                                                               |
+| `onOpenEnd`            | no       |                  | Callback fn that is called when the sheet opening animation is completed.                                                                                                                                                         |
+| `onCloseStart`         | no       |                  | Callback fn that is called when the sheet closing animation starts.                                                                                                                                                               |
+| `onCloseEnd`           | no       |                  | Callback fn that is called when the sheet closing animation is completed.                                                                                                                                                         |
+| `onSnap`               | no       |                  | Callback fn that is called with the current snap point index when the sheet snaps to a new snap point. Requires `snapPoints` prop.                                                                                                |
+| `snapPoints`           | no       |                  | Eg. `[-50, 0.5, 100, 0]` - where positive values are pixels from the bottom of the screen and negative from the top. Values between 0-1 represent percentages, eg. `0.5` means 50% of window height from the bottom of the sceen. |
+| `initialSnap`          | no       | 0                | Initial snap point when sheet is opened (index from `snapPoints`).                                                                                                                                                                |
+| `rootId`               | no       |                  | The id of the element where the main app is mounted, eg. "root". Enables iOS modal effect.                                                                                                                                        |
+| `springConfig`         | no       | `DEFAULT_SPRING` | Overrides the config for the [spring animation](https://www.framer.com/api/motion/types/#spring).                                                                                                                                 |
+| `mountPoint`           | no       | `document.body`  | HTML element that should be used as the mount point for the sheet.                                                                                                                                                                |
+| `prefersReducedMotion` | no       | false            | Skip sheet animations (sheet instantly snaps to desired location).                                                                                                                                                                |
 
 **`DEFAULT_SPRING`**
 
@@ -237,7 +238,7 @@ Sheet content acts as a drag target and makes sure that content which doesn't fi
 #### Content props
 
 | Name          | Required | Default | Description                         |
-| ------------- | -------- | ------- | ----------------------------------- |
+|---------------|----------|---------|-------------------------------------|
 | `disableDrag` | no       | false   | Disable drag for the sheet content. |
 
 ### `Sheet.Header`
@@ -249,7 +250,7 @@ Sheet header acts as a drag target and has a dragging direction indicator. Rende
 #### Header props
 
 | Name          | Required | Default | Description                        |
-| ------------- | -------- | ------- | ---------------------------------- |
+|---------------|----------|---------|------------------------------------|
 | `disableDrag` | no       | false   | Disable drag for the sheet header. |
 
 ### `Sheet.Backdrop`

--- a/src/SheetContainer.tsx
+++ b/src/SheetContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import mergeRefs from 'react-merge-refs';
 
 import { SheetContainerProps } from './types';
@@ -20,11 +20,19 @@ const SheetContainer = React.forwardRef<any, SheetContainerProps>(
       windowHeight,
       springConfig,
       detent = 'full-height',
+      prefersReducedMotion,
     } = useSheetContext();
 
     const { handleAnimationComplete } = useEventCallbacks(isOpen, callbacks);
     const initialY = snapPoints ? snapPoints[0] - snapPoints[initialSnap] : 0;
     const maxSnapHeight = snapPoints ? snapPoints[0] : null;
+    const shouldReduceMotion = useReducedMotion();
+    const initial =
+      prefersReducedMotion || shouldReduceMotion ? false : { y: windowHeight };
+    const transition =
+      prefersReducedMotion || shouldReduceMotion
+        ? { type: 'tween', duration: 0.01 }
+        : { type: 'spring', ...springConfig };
 
     const height =
       maxSnapHeight !== null
@@ -43,12 +51,12 @@ const SheetContainer = React.forwardRef<any, SheetContainerProps>(
           ...(detent === 'content-height' && { maxHeight: height }),
           y,
         }}
-        initial={{ y: windowHeight }}
+        initial={initial}
         animate={{
           y: initialY,
-          transition: { type: 'spring', ...springConfig },
+          transition,
         }}
-        exit={{ y: windowHeight }}
+        exit={{ y: windowHeight, transition }}
         onAnimationComplete={handleAnimationComplete}
       >
         {children}

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -7,6 +7,7 @@ import {
   AnimatePresence,
   PanInfo,
   useMotionValue,
+  useReducedMotion,
 } from 'framer-motion';
 
 import {
@@ -47,6 +48,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
       springConfig = DEFAULT_SPRING_CONFIG,
       disableDrag = false,
       style,
+      prefersReducedMotion = false,
       ...rest
     },
     ref
@@ -54,6 +56,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
     const sheetRef = React.useRef<any>(null);
     const indicatorRotation = useMotionValue(0);
     const windowHeight = useWindowHeight();
+    const shouldReduceMotion = useReducedMotion();
 
     // NOTE: the inital value for `y` doesn't matter since it is overwritten by
     // the value driven by the `AnimatePresence` component when the sheet is opened
@@ -134,7 +137,11 @@ const Sheet = React.forwardRef<any, SheetProps>(
         snapTo = validateSnapTo({ snapTo, sheetHeight });
 
         // Update the spring value so that the sheet is animated to the snap point
-        animate(y, snapTo, { type: 'spring', ...springConfig });
+        if (prefersReducedMotion || shouldReduceMotion) {
+          animate(y, snapTo, { type: 'tween', duration: 0.01 });
+        } else {
+          animate(y, snapTo, { type: 'spring', ...springConfig });
+        }
 
         if (snapPoints && onSnap) {
           const snapValue = Math.abs(Math.round(snapPoints[0] - snapTo));
@@ -173,7 +180,11 @@ const Sheet = React.forwardRef<any, SheetProps>(
             sheetHeight,
           });
 
-          animate(y, snapTo, { type: 'spring', ...springConfig });
+          if (prefersReducedMotion || shouldReduceMotion) {
+            animate(y, snapTo, { type: 'tween', duration: 0.01 });
+          } else {
+            animate(y, snapTo, { type: 'spring', ...springConfig });
+          }
 
           if (onSnap) onSnap(snapIndex);
           if (snapTo >= sheetHeight) onClose();
@@ -212,6 +223,7 @@ const Sheet = React.forwardRef<any, SheetProps>(
       dragProps,
       windowHeight,
       springConfig,
+      prefersReducedMotion,
     };
 
     const sheet = (

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -26,6 +26,7 @@ export type SheetProps = {
   initialSnap?: number; // index of snap points array
   springConfig?: Parameters<typeof useSpring>[1];
   disableDrag?: boolean;
+  prefersReducedMotion?: boolean;
 } & SheetEvents &
   React.HTMLAttributes<HTMLDivElement>;
 
@@ -76,6 +77,7 @@ export type SheetContextType = {
   dragProps?: SheetDragProps;
   windowHeight: number;
   springConfig: Parameters<typeof useSpring>[1];
+  prefersReducedMotion?: boolean;
 };
 
 type ContainerComponent = React.ForwardRefExoticComponent<


### PR DESCRIPTION
First of all, thanks @Temzasse for putting this library together! Was great to use for our project.

This PR adds better support for a11y if a user prefers reduced motion. The component automatically checks for the user's preferences using Framer Motion's [`useReducedMotion` hook](https://www.framer.com/docs/guide-accessibility/#usereducedmotion). An override is also exposed in `prefersReducedMotion`, a prop that can be provided to the Sheet root.

When either of these flags are `true`, the sheet spring animation is replaced with an instant value update. The opacity of the sheet is also updated so that the sheet is hidden during the height (y-value) update.