### PR TITLE
Fix for modal dragConstraints breaking when window is resized

### DIFF
--- a/src/SheetContent.tsx
+++ b/src/SheetContent.tsx
@@ -7,18 +7,20 @@ import styles from './styles';
 
 const SheetContent = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { dragProps } = useSheetContext();
+    const { windowHeight, dragProps } = useSheetContext();
 
     return (
-      <motion.div
-        {...rest}
-        ref={ref}
-        className="react-modal-sheet-content"
-        style={{ ...styles.content, ...style }}
-        {...dragProps}
-      >
-        {children}
-      </motion.div>
+      <React.Fragment key={windowHeight}>
+        <motion.div
+          {...rest}
+          ref={ref}
+          className="react-modal-sheet-content"
+          style={{ ...styles.content, ...style }}
+          {...dragProps}
+        >
+          {children}
+        </motion.div>
+      </React.Fragment>
     );
   }
 );

--- a/src/SheetHeader.tsx
+++ b/src/SheetHeader.tsx
@@ -7,7 +7,7 @@ import styles from './styles';
 
 const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { indicatorRotation, dragProps } = useSheetContext();
+    const { windowHeight, indicatorRotation, dragProps } = useSheetContext();
 
     const indicator1Transform = useTransform(
       indicatorRotation,
@@ -20,25 +20,27 @@ const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
     );
 
     return (
-      <motion.div
-        {...rest}
-        ref={ref}
-        style={{ ...styles.headerWrapper, ...style }}
-        {...dragProps}
-      >
-        {children || (
-          <div className="react-modal-sheet-header" style={styles.header}>
-            <motion.span
-              className="react-modal-sheet-drag-indicator"
-              style={{ ...styles.indicator, transform: indicator1Transform }}
-            />
-            <motion.span
-              className="react-modal-sheet-drag-indicator"
-              style={{ ...styles.indicator, transform: indicator2Transform }}
-            />
-          </div>
-        )}
-      </motion.div>
+      <React.Fragment key={windowHeight}>
+        <motion.div
+          {...rest}
+          ref={ref}
+          style={{ ...styles.headerWrapper, ...style }}
+          {...dragProps}
+        >
+          {children || (
+            <div className="react-modal-sheet-header" style={styles.header}>
+              <motion.span
+                className="react-modal-sheet-drag-indicator"
+                style={{ ...styles.indicator, transform: indicator1Transform }}
+              />
+              <motion.span
+                className="react-modal-sheet-drag-indicator"
+                style={{ ...styles.indicator, transform: indicator2Transform }}
+              />
+            </div>
+          )}
+        </motion.div>
+      </React.Fragment>
     );
   }
 );


### PR DESCRIPTION
Framer currently has a bug where dragConstraints stop working when the window is resized (https://github.com/framer/motion/issues/1659). This bug carries itself over to this library, where you can drag Sheet.Content and Sheet.Header outside of the modal bounds if you resize the window. You can test this using the example webpage in README.md

This PR is a temporary fix for this issue by attaching a key dependent on windowHeight to Sheet.Content and Sheet.Header, so that those components re-render with the correct constraints when the window is resized.