### PR TITLE
Fix for disableDrag not working on Sheet Content and Sheet Header

### DIFF
--- a/src/SheetContent.tsx
+++ b/src/SheetContent.tsx
@@ -6,8 +6,9 @@ import { useSheetContext } from './context';
 import styles from './styles';
 
 const SheetContent = React.forwardRef<any, SheetDraggableProps>(
-  ({ children, style, ...rest }, ref) => {
+  ({ children, style, disableDrag, ...rest }, ref) => {
     const { dragProps } = useSheetContext();
+    const _dragProps = disableDrag ? undefined : dragProps;
 
     return (
       <motion.div
@@ -15,7 +16,7 @@ const SheetContent = React.forwardRef<any, SheetDraggableProps>(
         ref={ref}
         className="react-modal-sheet-content"
         style={{ ...styles.content, ...style }}
-        {...dragProps}
+        {..._dragProps}
       >
         {children}
       </motion.div>

--- a/src/SheetContent.tsx
+++ b/src/SheetContent.tsx
@@ -7,20 +7,18 @@ import styles from './styles';
 
 const SheetContent = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { windowHeight, dragProps } = useSheetContext();
+    const { dragProps } = useSheetContext();
 
     return (
-      <React.Fragment key={windowHeight}>
-        <motion.div
-          {...rest}
-          ref={ref}
-          className="react-modal-sheet-content"
-          style={{ ...styles.content, ...style }}
-          {...dragProps}
-        >
-          {children}
-        </motion.div>
-      </React.Fragment>
+      <motion.div
+        {...rest}
+        ref={ref}
+        className="react-modal-sheet-content"
+        style={{ ...styles.content, ...style }}
+        {...dragProps}
+      >
+        {children}
+      </motion.div>
     );
   }
 );

--- a/src/SheetContent.tsx
+++ b/src/SheetContent.tsx
@@ -7,18 +7,20 @@ import styles from './styles';
 
 const SheetContent = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { dragProps } = useSheetContext();
+    const { windowHeight, dragProps } = useSheetContext();
 
     return (
-      <motion.div
-        {...rest}
-        ref={ref}
-        className="react-modal-sheet-content"
-        style={{ ...styles.content, ...style }}
-        {...dragProps}
-      >
-        {children}
-      </motion.div>
+      <React.Fragment key={windowHeight}>
+        <motion.div
+          {...rest}
+          ref={ref}
+          className="react-modal-sheet-content"
+          style={{ ...styles.content, ...style }}
+          {...dragProps}
+        >
+          {children}
+        </motion.div>
+      </React.Fragment>
     );
   }
 );

--- a/src/SheetHeader.tsx
+++ b/src/SheetHeader.tsx
@@ -6,8 +6,9 @@ import { useSheetContext } from './context';
 import styles from './styles';
 
 const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
-  ({ children, style, ...rest }, ref) => {
+  ({ children, style, disableDrag, ...rest }, ref) => {
     const { indicatorRotation, dragProps } = useSheetContext();
+    const _dragProps = disableDrag ? undefined : dragProps;
 
     const indicator1Transform = useTransform(
       indicatorRotation,
@@ -24,7 +25,7 @@ const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
         {...rest}
         ref={ref}
         style={{ ...styles.headerWrapper, ...style }}
-        {...dragProps}
+        {..._dragProps}
       >
         {children || (
           <div className="react-modal-sheet-header" style={styles.header}>

--- a/src/SheetHeader.tsx
+++ b/src/SheetHeader.tsx
@@ -7,7 +7,7 @@ import styles from './styles';
 
 const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { indicatorRotation, dragProps } = useSheetContext();
+    const { windowHeight, indicatorRotation, dragProps } = useSheetContext();
 
     const indicator1Transform = useTransform(
       indicatorRotation,
@@ -20,25 +20,27 @@ const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
     );
 
     return (
-      <motion.div
-        {...rest}
-        ref={ref}
-        style={{ ...styles.headerWrapper, ...style }}
-        {...dragProps}
-      >
-        {children || (
-          <div className="react-modal-sheet-header" style={styles.header}>
-            <motion.span
-              className="react-modal-sheet-drag-indicator"
-              style={{ ...styles.indicator, transform: indicator1Transform }}
-            />
-            <motion.span
-              className="react-modal-sheet-drag-indicator"
-              style={{ ...styles.indicator, transform: indicator2Transform }}
-            />
-          </div>
-        )}
-      </motion.div>
+      <React.Fragment key={windowHeight}>
+        <motion.div
+          {...rest}
+          ref={ref}
+          style={{ ...styles.headerWrapper, ...style }}
+          {...dragProps}
+        >
+          {children || (
+            <div className="react-modal-sheet-header" style={styles.header}>
+              <motion.span
+                className="react-modal-sheet-drag-indicator"
+                style={{ ...styles.indicator, transform: indicator1Transform }}
+              />
+              <motion.span
+                className="react-modal-sheet-drag-indicator"
+                style={{ ...styles.indicator, transform: indicator2Transform }}
+              />
+            </div>
+          )}
+        </motion.div>
+      </React.Fragment>
     );
   }
 );

--- a/src/SheetHeader.tsx
+++ b/src/SheetHeader.tsx
@@ -7,7 +7,7 @@ import styles from './styles';
 
 const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
   ({ children, style, ...rest }, ref) => {
-    const { windowHeight, indicatorRotation, dragProps } = useSheetContext();
+    const { indicatorRotation, dragProps } = useSheetContext();
 
     const indicator1Transform = useTransform(
       indicatorRotation,
@@ -20,27 +20,25 @@ const SheetHeader = React.forwardRef<any, SheetDraggableProps>(
     );
 
     return (
-      <React.Fragment key={windowHeight}>
-        <motion.div
-          {...rest}
-          ref={ref}
-          style={{ ...styles.headerWrapper, ...style }}
-          {...dragProps}
-        >
-          {children || (
-            <div className="react-modal-sheet-header" style={styles.header}>
-              <motion.span
-                className="react-modal-sheet-drag-indicator"
-                style={{ ...styles.indicator, transform: indicator1Transform }}
-              />
-              <motion.span
-                className="react-modal-sheet-drag-indicator"
-                style={{ ...styles.indicator, transform: indicator2Transform }}
-              />
-            </div>
-          )}
-        </motion.div>
-      </React.Fragment>
+      <motion.div
+        {...rest}
+        ref={ref}
+        style={{ ...styles.headerWrapper, ...style }}
+        {...dragProps}
+      >
+        {children || (
+          <div className="react-modal-sheet-header" style={styles.header}>
+            <motion.span
+              className="react-modal-sheet-drag-indicator"
+              style={{ ...styles.indicator, transform: indicator1Transform }}
+            />
+            <motion.span
+              className="react-modal-sheet-drag-indicator"
+              style={{ ...styles.indicator, transform: indicator2Transform }}
+            />
+          </div>
+        )}
+      </motion.div>
     );
   }
 );


### PR DESCRIPTION
This PR is in response to the issues I encountered in https://github.com/Temzasse/react-modal-sheet/issues/98.

Sheet.Content and Sheet.Header have the disableDrag prop, but passing this prop does absolutely nothing. The expected behavior is that the dragProps prop responsible for drag behavior should be set to undefined when disableDrag is passed in. 

Currently this behavior is only implemented for the parent Sheet component. This PR implements this behavior for Sheet.Content and Sheet.Header as well.