### PR TITLE
Remove border from backdrop

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -20,6 +20,7 @@ const styles: { [key: string]: CSS.Properties } = {
     height: '100%',
     backgroundColor: 'rgba(51, 51, 51, 0.5)',
     touchAction: 'none', // Disable iOS body scrolling
+    border: 'none',
   },
   container: {
     zIndex: 2,


### PR DESCRIPTION
There is a border on the backdrop if the backdrop is clickable. I think we should remove the borders to achieve consistent UI. 