### PR TITLE
Add simple mergeRefs function

### DIFF
--- a/src/SheetContainer.tsx
+++ b/src/SheetContainer.tsx
@@ -1,12 +1,25 @@
 import * as React from 'react';
 import { motion } from 'framer-motion';
-import { mergeRefs } from 'react-merge-refs';
 
 import { SheetContainerProps } from './types';
 import { useSheetContext } from './context';
 import { useEventCallbacks } from './hooks';
 import { MAX_HEIGHT } from './constants';
 import styles from './styles';
+
+function mergeRefs<T = any>(
+  refs: React.ForwardedRef<T>[]
+): React.RefCallback<T> {
+  return (value: any) => {
+    refs.forEach((ref: any) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref) {
+        ref.current = value;
+      }
+    });
+  };
+}
 
 const SheetContainer = React.forwardRef<any, SheetContainerProps>(
   ({ children, style = {}, className = '', ...rest }, ref) => {


### PR DESCRIPTION
[Since react-merge-refs 2.0.0, we have confirmed that cjs build versions are not supported.](https://github.com/gregberge/react-merge-refs/releases/tag/v2.0.0)

Additionally, an issue occurred in the current Next.js + SSR situation, and as a result of debugging, it was an issue that occurred in the react-merge-refs library.

Therefore, we applied a simple refs merge function.