### PR TITLE
Fix sheet not closing properly after slow drag to bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.1",
+  "version": "1.10.2",
   "license": "MIT",
   "name": "react-modal-sheet",
   "description": "Flexible bottom sheet component for your React apps",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.2",
+  "version": "1.10.1",
   "license": "MIT",
   "name": "react-modal-sheet",
   "description": "Flexible bottom sheet component for your React apps",

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -150,7 +150,10 @@ const Sheet = React.forwardRef<any, SheetProps>(
           onSnap(snapIndex);
         }
 
-        if (snapTo >= sheetHeight) onClose();
+        const roundedSheetHeight = Math.round(sheetHeight);
+        const shouldClose = snapTo >= roundedSheetHeight;
+
+        if (shouldClose) onClose();
       }
 
       // Reset indicator rotation after dragging


### PR DESCRIPTION
## Issue
When a user slowly drags the sheet to the bottom, the sheet does not always close as expected.
You can see this behavior in the following video

https://user-images.githubusercontent.com/3205737/223282060-ad979fa6-a2f0-4603-9ed4-41e25abb9e7b.mp4

## Solution
To fix this issue I made a very little adjustment.

From: 
```javascript
if (snapTo >= sheetHeight) onClose();
```
To: 
```javascript
const roundedSheetHeight = Math.round(sheetHeight);
const shouldClose = snapTo >= roundedSheetHeight;
if (shouldClose) onClose();
```

This change ensures that we are comparing rounded values when checking if the sheet should close. 
Remember that `snapTo` has been rounded when `validateSnapTo`  function was called.