### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ You can add your own styles or override the default sheet styles via the exposed
 #### CSS-in-JS
 
 ```jsx
-import Sheet from 'react-modal-sheeet';
+import Sheet from 'react-modal-sheet';
 import styled from 'styled-components';
 import { useState } from 'react';
 


### PR DESCRIPTION
## Issue

Copying and using the CSS-in-JS example code in the Custom styles section of README does not work. The cause is "sheeet" typo.


## Solution
I corrected the typo "sheeet" to "sheet".

From:
```javascript
import Sheet from 'react-modal-sheeet';
```

To:

```javascript
import Sheet from 'react-modal-sheet';
```