### PR TITLE
Add example for Standard Bottom Sheet

### DIFF
--- a/example/components/App.tsx
+++ b/example/components/App.tsx
@@ -20,6 +20,7 @@ import A11y from './a11y';
 import DisableDrag from './DisableDrag';
 import ScrollableSnapPoints from './ScrollableSnapPoints';
 import ContentHeight from './ContentHeight';
+import Standard from './standard';
 
 const App = () => {
   return (
@@ -98,6 +99,14 @@ const App = () => {
           </Screen>
         }
       />
+      <Route
+        path="standard/*"
+        element={
+          <Screen bg="light">
+            <Standard />
+          </Screen>
+        }
+      />
     </Routes>
   );
 };
@@ -158,6 +167,13 @@ const ExampleSelector = () => {
         <ExampleLink to="a11y">
           <A11yIcon size={48} />
           <span>Accessible Sheet</span>
+        </ExampleLink>
+      </li>
+
+      <li>
+        <ExampleLink to="standard">
+          {/* TODO: add icon? */}
+          <span>Standard Bottom Sheet</span>
         </ExampleLink>
       </li>
     </ExampleLinks>

--- a/example/components/App.tsx
+++ b/example/components/App.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Routes, Route, Link } from 'react-router-dom';
 import { FaScroll as ScrollIcon, FaLock as LockIcon } from 'react-icons/fa';
 import { MdAccessibility as A11yIcon } from 'react-icons/md';
+import { BiDockBottom as DockBottomIcon } from 'react-icons/bi';
 
 import {
   AiOutlineColumnHeight as HeightIcon,
@@ -10,7 +11,6 @@ import {
   AiOutlineSlack as SlackIcon,
   AiOutlineControl as SnapIcon,
 } from 'react-icons/ai';
-
 import { Screen, DarkMode } from './common';
 import SnapPoints from './SnapPoints';
 import Scrollable from './Scrollable';
@@ -172,7 +172,7 @@ const ExampleSelector = () => {
 
       <li>
         <ExampleLink to="standard">
-          {/* TODO: add icon? */}
+          <DockBottomIcon size={48} />
           <span>Standard Bottom Sheet</span>
         </ExampleLink>
       </li>

--- a/example/components/standard/StandardBottomSheet.tsx
+++ b/example/components/standard/StandardBottomSheet.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import Sheet, { SheetRef } from '../../../src';
+import { SheetProps } from '../../../src/types';
+
+type StandardBottomSheet = SheetProps & {
+  snapPoints: Exclude<SheetProps['snapPoints'], undefined>;
+  closedSnapIndex: number;
+  onOpen?: () => void;
+};
+
+export const StandardBottomSheet: React.FC<StandardBottomSheet> = ({
+  isOpen,
+  snapPoints,
+  initialSnap = 0,
+  closedSnapIndex,
+  onOpen,
+  onClose,
+  onSnap,
+  ...restProps
+}) => {
+  const ref = React.useRef<SheetRef>();
+  const snapTo = (snapPoint: number) => ref.current?.snapTo(snapPoint);
+  const [isOpenFlushing, setIsOpenFlushing] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    snapTo(isOpen ? initialSnap : closedSnapIndex);
+  }, [isOpen, initialSnap, closedSnapIndex]);
+
+  const handleSnap = React.useCallback(
+    (snapPoint: number) => {
+      if (onSnap) onSnap(snapPoint);
+      if (snapPoint === closedSnapIndex) {
+        onClose();
+      } else {
+        if (onOpen && isOpen === false) onOpen();
+      }
+    },
+    [onClose, onSnap, closedSnapIndex]
+  );
+
+  const handleClose = React.useCallback(() => {
+    // NOTE: If you drag a header to the bottom of the window and end the drag by pushing it off-screen,
+    //       the header may not come back from off-screen. This is known to be a problem caused by
+    //       the internal open/close state of the Sheet component being closed.
+    //       - ref: https://github.com/Temzasse/react-modal-sheet/issues/105
+    //       To work around this problem, here we flush `isOpen` props to true, prompting the sheet to be rendered in an open state.
+    setIsOpenFlushing(true);
+    setIsOpenFlushing(false);
+    if (isOpen === true) onClose();
+  }, [closedSnapIndex, onClose]);
+
+  return (
+    <Sheet
+      ref={ref}
+      onClose={handleClose}
+      isOpen={isOpenFlushing === false ? true : false}
+      snapPoints={snapPoints}
+      initialSnap={closedSnapIndex}
+      onSnap={handleSnap}
+      {...restProps}
+    />
+  );
+};

--- a/example/components/standard/StandardBottomSheet.tsx
+++ b/example/components/standard/StandardBottomSheet.tsx
@@ -2,17 +2,19 @@ import * as React from 'react';
 import Sheet, { SheetRef } from '../../../src';
 import { SheetProps } from '../../../src/types';
 
-type StandardBottomSheet = SheetProps & {
-  snapPoints: Exclude<SheetProps['snapPoints'], undefined>;
-  closedSnapIndex: number;
+const OPENED_SNAP_INDEX = 0;
+const CLOSED_SNAP_INDEX = 1;
+
+type StandardBottomSheet = Omit<SheetProps, 'snapPoints' | 'initialSnap'> & {
+  openSnapPoint: number;
+  closedSnapPoint: number;
   onOpen?: () => void;
 };
 
 export const StandardBottomSheet: React.FC<StandardBottomSheet> = ({
   isOpen,
-  snapPoints,
-  initialSnap = 0,
-  closedSnapIndex,
+  openSnapPoint,
+  closedSnapPoint,
   onOpen,
   onClose,
   onSnap,
@@ -21,21 +23,22 @@ export const StandardBottomSheet: React.FC<StandardBottomSheet> = ({
   const ref = React.useRef<SheetRef>();
   const snapTo = (snapPoint: number) => ref.current?.snapTo(snapPoint);
   const [isOpenFlushing, setIsOpenFlushing] = React.useState<boolean>(false);
+  const snapPoints = React.useMemo(() => [openSnapPoint, closedSnapPoint], [openSnapPoint, closedSnapPoint])
 
   React.useEffect(() => {
-    snapTo(isOpen ? initialSnap : closedSnapIndex);
-  }, [isOpen, initialSnap, closedSnapIndex]);
+    snapTo(isOpen ? OPENED_SNAP_INDEX : CLOSED_SNAP_INDEX);
+  }, [isOpen, OPENED_SNAP_INDEX, CLOSED_SNAP_INDEX]);
 
   const handleSnap = React.useCallback(
     (snapPoint: number) => {
       if (onSnap) onSnap(snapPoint);
-      if (snapPoint === closedSnapIndex) {
+      if (snapPoint === CLOSED_SNAP_INDEX) {
         onClose();
       } else {
         if (onOpen && isOpen === false) onOpen();
       }
     },
-    [onClose, onSnap, closedSnapIndex]
+    [onClose, onSnap, CLOSED_SNAP_INDEX]
   );
 
   const handleClose = React.useCallback(() => {
@@ -47,7 +50,7 @@ export const StandardBottomSheet: React.FC<StandardBottomSheet> = ({
     setIsOpenFlushing(true);
     setIsOpenFlushing(false);
     if (isOpen === true) onClose();
-  }, [closedSnapIndex, onClose]);
+  }, [CLOSED_SNAP_INDEX, onClose]);
 
   return (
     <Sheet
@@ -55,7 +58,7 @@ export const StandardBottomSheet: React.FC<StandardBottomSheet> = ({
       onClose={handleClose}
       isOpen={isOpenFlushing === false ? true : false}
       snapPoints={snapPoints}
-      initialSnap={closedSnapIndex}
+      initialSnap={CLOSED_SNAP_INDEX}
       onSnap={handleSnap}
       {...restProps}
     />

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -3,17 +3,14 @@ import styled from 'styled-components';
 
 import Sheet from '../../../src';
 import { Button } from '../common';
-import { useMeasure } from 'react-use';
 import { StandardBottomSheet } from './StandardBottomSheet';
 
-const OPENED_SNAP_INDEX = 0;
-const CLOSED_SNAP_INDEX = 1;
+const HEADER_HEIGHT = 80;
 
 /**
  * A sheet that shows only `<Sheet.Header>` when closed and both `<Sheet.Header>` and `<Sheet.Content>` when open.
  */
 const Standard = () => {
-  const [headerRef, { height: headerHeight }] = useMeasure();
   // FIXME: The opened sheet is rendered momentarily immediately after the page is loaded.
   //        This behavior is incorrect because the sheet is initially closed.
   //
@@ -36,12 +33,11 @@ const Standard = () => {
         // Set snap points consisting of '40% of window height' and 'header height'.
         //
         // FIXME: The 'Snap points need to be in descending order' warning is triggered when 40% of window height is smaller than header height.
-        snapPoints={headerHeight === 0 ? [0.4, 0] : [0.4, headerHeight]}
-        initialSnap={OPENED_SNAP_INDEX}
-        closedSnapIndex={CLOSED_SNAP_INDEX}
+        openSnapPoint={0.8}
+        closedSnapPoint={HEADER_HEIGHT}
       >
         <Sheet.Container>
-          <Sheet.Header ref={headerRef}>
+          <Sheet.Header style={{ height: HEADER_HEIGHT }}>
             <HeaderContent onClick={toggleOpen}>
               {isOpen
                 ? 'Click or drag here to close ⬇️'

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+import Sheet from '../../../src';
+import { Button } from '../common';
+import { useMeasure } from 'react-use';
+import { StandardBottomSheet } from './StandardBottomSheet';
+
+const OPENED_SNAP_INDEX = 0;
+const CLOSED_SNAP_INDEX = 1;
+
+/**
+ * A sheet that shows only `<Sheet.Header>` when closed and both `<Sheet.Header>` and `<Sheet.Content>` when open.
+ */
+const Standard = () => {
+  const [headerRef, { height: headerHeight }] = useMeasure();
+  // FIXME: The opened sheet is rendered momentarily immediately after the page is loaded.
+  //        This behavior is incorrect because the sheet is initially closed.
+  //
+  // FIXME: When a sheet is open, changing the height of the window causes it to switch to showing only `<Sheet.Header>.
+  //        This behavior is incorrect because `isOpen` remains `true`.
+  const [isOpen, setOpen] = React.useState(false);
+
+  const open = React.useCallback(() => setOpen(true), []);
+  const close = React.useCallback(() => setOpen(false), []);
+  const toggleOpen = React.useCallback(() => setOpen(prev => !prev), []);
+
+  return (
+    <>
+      <Button onClick={open}>Bottom Sheet with Snap Points</Button>
+
+      <StandardBottomSheet
+        isOpen={isOpen}
+        onOpen={open}
+        onClose={close}
+        // Set snap points consisting of '40% of window height' and 'header height'.
+        //
+        // FIXME: The 'Snap points need to be in descending order' warning is triggered when 40% of window height is smaller than header height.
+        snapPoints={headerHeight === 0 ? [0.4, 0] : [0.4, headerHeight]}
+        initialSnap={OPENED_SNAP_INDEX}
+        closedSnapIndex={CLOSED_SNAP_INDEX}
+      >
+        <Sheet.Container>
+          <Sheet.Header ref={headerRef}>
+            <HeaderContent onClick={toggleOpen}>
+              {isOpen
+                ? 'Click or drag here to close'
+                : 'Click or drag here to open'}
+            </HeaderContent>
+          </Sheet.Header>
+          <Sheet.Content disableDrag>
+            <Sheet.Scroller>
+              {Array.from({ length: 20 }, (_, i) => (
+                <p key={i}>This is the content.</p>
+              ))}
+            </Sheet.Scroller>
+          </Sheet.Content>
+        </Sheet.Container>
+        {/*
+         * NOTE: Passing `false` or `null` for `<Sheet>` children will result in a runtime error.
+         *       To avoid this, fragment (`<></>`) is passed here.
+         *
+         * FIXME: When `isOpen === false`, the backdrop immediately disappears. It should fade out.
+         */}
+        {isOpen ? <Sheet.Backdrop onTap={close} /> : <></>}
+      </StandardBottomSheet>
+    </>
+  );
+};
+
+const HeaderContent = styled.button`
+  font-size: xx-large;
+  font-weight: bold;
+  text-align: center;
+
+  display: block;
+  width: 100%;
+  padding: 16px;
+
+  cursor: pointer;
+`;
+
+export default Standard;

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -27,7 +27,7 @@ const Standard = () => {
 
   return (
     <>
-      <Button onClick={open}>Bottom Sheet with Snap Points</Button>
+      <Button onClick={open}>Open Sheet</Button>
 
       <StandardBottomSheet
         isOpen={isOpen}

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -40,8 +40,8 @@ const Standard = () => {
           <Sheet.Header style={{ height: HEADER_HEIGHT }}>
             <HeaderContent onClick={toggleOpen}>
               {isOpen
-                ? 'Click or drag here to close ⬇️'
-                : 'Click or drag here to open ⬆️'}
+                ? 'Click or drag here ⬇️'
+                : 'Click or drag here ⬆️'}
             </HeaderContent>
           </Sheet.Header>
           <Sheet.Content disableDrag>

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -31,8 +31,6 @@ const Standard = () => {
         onOpen={open}
         onClose={close}
         // Set snap points consisting of '40% of window height' and 'header height'.
-        //
-        // FIXME: The 'Snap points need to be in descending order' warning is triggered when 40% of window height is smaller than header height.
         openSnapPoint={0.8}
         closedSnapPoint={HEADER_HEIGHT}
       >

--- a/example/components/standard/index.tsx
+++ b/example/components/standard/index.tsx
@@ -44,8 +44,8 @@ const Standard = () => {
           <Sheet.Header ref={headerRef}>
             <HeaderContent onClick={toggleOpen}>
               {isOpen
-                ? 'Click or drag here to close'
-                : 'Click or drag here to open'}
+                ? 'Click or drag here to close ⬇️'
+                : 'Click or drag here to open ⬆️'}
             </HeaderContent>
           </Sheet.Header>
           <Sheet.Content disableDrag>


### PR DESCRIPTION
Hello. I have saved hours of time by using this library. Thanks!

I want a sheet that shows only `<Sheet.Header>` when closed and both `<Sheet.Header>` and `<Sheet.Content>` when open. The main content of the page can still be accessed when only `<Sheet.Header>` is displayed. This is called "Standard Bottom Sheet" in the material design documentation.

- https://m3.material.io/components/bottom-sheets/guidelines

Several people besides me seem to want this feature.

- https://github.com/Temzasse/react-modal-sheet/issues/6
- https://github.com/Temzasse/react-modal-sheet/issues/105

While this feature can be implemented using react-modal-sheet, it is tricky to implement. Also, it is not a case that is generously supported by react-modal-sheet, so some behavior will not be as expected.

To solve this problem, I thought it would be good to have a reference implementation of Standard Bottom Sheet. With it, anyone can implement the Standard Bottom Sheet. It would also make it possible to identify what kind of behavior is not as expected.

So I created a reference implementation of the Standard Bottom Sheet and created this PR to add to the example.

Could you accept this proposal?

## DEMO

https://github.com/Temzasse/react-modal-sheet/assets/9639995/cc0da5d3-3df8-4188-b27c-c6ae439383a6

## NOTE

I have written code comments detailing some of the bugs I found during the creation of the reference implementation. These should be transcribed in a separate issue, but we will not do that yet. I will do so when this PR is merged.
