### PR TITLE
fix: enable Sheet.Scroller to handle onScroll and onTouchStart on touch devices

### DIFF
--- a/src/SheetScroller.tsx
+++ b/src/SheetScroller.tsx
@@ -32,10 +32,16 @@ const SheetScroller = forwardRef<any, SheetScrollerProps>(
 
     function onScroll(e: UIEvent<HTMLDivElement>) {
       determineDragState(e.currentTarget);
+      if (rest.onScroll) {
+        rest.onScroll(e);
+      }
     }
 
     function onTouchStart(e: TouchEvent<HTMLDivElement>) {
       determineDragState(e.currentTarget);
+      if (rest.onTouchStart) {
+        rest.onTouchStart(e);
+      }
     }
 
     const scrollProps = isTouchDevice()


### PR DESCRIPTION
Do not overwrite `onScroll` and `onTouchStart` event on touch devices it they exist.

I had a case when `onScroll` on Sheet.Scroller worked on desktop and didn't work on mobile 😢 .