### PR TITLE
Fix for dragging on the scrollable sheet content to dismiss

### DIFF
--- a/src/SheetContent.tsx
+++ b/src/SheetContent.tsx
@@ -77,6 +77,10 @@ export const SheetContent = forwardRef<any, SheetContentProps>(
       scrollStyle.overflowY = 'hidden';
     }
 
+    if (dragProps !== undefined) {
+      scrollStyle.touchAction = 'pan-down';
+    }
+
     return (
       <motion.div
         {...rest}

--- a/src/hooks/use-scroll-position.ts
+++ b/src/hooks/use-scroll-position.ts
@@ -81,6 +81,8 @@ export function useScrollPosition(options: UseScrollPositionOptions = {}) {
         position = 'middle';
       }
 
+      element.style.touchAction = isAtTop ? 'pan-down' : '';
+
       if (position === scrollPosition) return;
       setScrollPosition(position);
     }


### PR DESCRIPTION
Fixes: https://github.com/Temzasse/react-modal-sheet/issues/154

On mobile devices, dragging on the sheet content area to dismiss it did not work.

When Sheet.Content has scrollable content, the outer motion.div gets `touch-action: none` from Framer Motion (enabling drag), but the inner scroller div retains its default touch handling.
Mobile browsers treat this inner overflow: auto element as a native scroll container and capture the touch gesture for scrolling, firing a pointercancel event that terminates Framer Motion's drag detection before it can register movement. 

Fix

When drag is active on the content element, set `touch-action: pan-down` on the inner scroller. This tells the browser to only handle downward pan gestures (scrolling content up to read above).

Change in use-scroll-position hook fixes the same issue for custom scrollers. 

Tested on: desktop and mobile Chrome, MacOS Safari and iOS Safari