### PR TITLE
Prevent backdrop flash on sheet opening

### DIFF
--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -26,6 +26,7 @@ import {
 } from './constants';
 import { ExposedSheetContext, InternalSheetContext } from './context';
 import { useDimensions } from './hooks/use-dimensions';
+import { useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect';
 import { useKeyboardAvoidance } from './hooks/use-keyboard-avoidance';
 import { useModalEffect } from './hooks/use-modal-effect';
 import { usePreventScroll } from './hooks/use-prevent-scroll';
@@ -319,6 +320,12 @@ export const Sheet = forwardRef<any, SheetProps>(
         onCloseEnd?.();
       },
     });
+
+    useIsomorphicLayoutEffect(() => {
+      if (state === 'opening') {
+        y.set(closedY);
+      }
+    }, [state, closedY, y]);
 
     const dragProps: InternalContextType['dragProps'] = {
       drag: 'y',


### PR DESCRIPTION
This PR fixes an intermittent backdrop flicker when opening the sheet

In some openings, the backdrop briefly renders at high opacity before animating correctly

(visual sequence like 1 -> 0 -> 0.1 -> 0.2, ...)

This happens because backdrop opacity is derived from `yProgress`, and `y` can momentarily keep a stale value during the transition to `opening`, before the `async onOpen` flow starts

The fix sets `y` to `closedY` in `useIsomorphicLayoutEffect` when state becomes `opening`
Doing this in layout phase guarantees the first painted frame starts from the closed position, preventing the flash and preserving the normal open animation